### PR TITLE
fix: update module resolution configuration for Next.js 15

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,7 @@
 /** @type {import('next').NextConfig} */
+const path = require('path')
+
 const nextConfig = {
-  experimental: {
-    turbo: {
-      resolveAlias: {
-        '@': '.',
-      },
-    },
-  },
   typescript: {
     ignoreBuildErrors: false,
   },
@@ -14,10 +9,10 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   transpilePackages: ['@tanstack/react-query'],
-  webpack: (config, { isServer }) => {
+  webpack: (config, options) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      '@': require('path').resolve(__dirname),
+      '@': path.resolve(__dirname),
     }
     return config
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,12 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
- Change moduleResolution from 'bundler' to 'node' in tsconfig.json
- Add baseUrl configuration to tsconfig.json
- Simplify next.config.js webpack alias configuration
- Remove experimental turbo configuration that was causing issues
- Ensure proper path resolution for @/* imports

🤖 Generated with [Claude Code](https://claude.ai/code)